### PR TITLE
Use RGB color ordering

### DIFF
--- a/03_execution/run.py
+++ b/03_execution/run.py
@@ -15,7 +15,7 @@ def chunks(lst, n):
 sleep_time = 0.017  # approx 60fps
 
 NUMBEROFLEDS = 500
-pixels = neopixel.NeoPixel(board.D18, NUMBEROFLEDS, auto_write=False)
+pixels = neopixel.NeoPixel(board.D18, NUMBEROFLEDS, auto_write=False, pixel_order=neopixel.RGB)
 
 csvFile = sys.argv[1]
 
@@ -44,7 +44,7 @@ with open(csvFile, 'r') as read_obj:
                 r = float(chunked_list[element_num][0])
                 g = float(chunked_list[element_num][1])
                 b = float(chunked_list[element_num][2])
-                light_val = (g, r, b)
+                light_val = (r, g, b)
                 # turn that led on
                 parsed_row.append(light_val)
             


### PR DESCRIPTION
The LEDs never were taking the values in GRB order. However, the library
thought they were (because of a tricky default), so it was changing the
order before sending it to the LEDs, which made it look like you had to
set the colors in GRB order. You never have to if you initialize the
library with the correct color ordering.

This initializes the library with the right color order setting, and
removes the work-around.